### PR TITLE
Fix windows build after databento-cpp v0.53.0 version.

### DIFF
--- a/src/Databento.Native/src/live_client_wrapper.cpp
+++ b/src/Databento.Native/src/live_client_wrapper.cpp
@@ -1,3 +1,7 @@
+#ifndef NOMINMAX
+# define NOMINMAX
+#endif
+
 #include "databento_native.h"
 #include "common_helpers.hpp"
 #include "handle_validation.hpp"


### PR DESCRIPTION
Fix https://github.com/Alparse/databento-dotnet/issues/24
Fix windows build after `databento-cpp v0.53.0` version due to include reordering.